### PR TITLE
Add username fetch from Firestore to HomeScreen

### DIFF
--- a/src/navigation/AuthNavigator.js
+++ b/src/navigation/AuthNavigator.js
@@ -9,6 +9,7 @@ import SignUpScreen from '../screens/SignUpScreen';
 import ForgotPasswordScreen from '../screens/ForgotPasswordScreen';
 import ResetPasswordScreen from '../screens/ResetPasswordScreen';
 import PasswordResetVerificationScreen from '../screens/PasswordResetVerificationScreen';
+import TermandConditions from '../screens/TermandConditions';
 
 const Stack = createNativeStackNavigator();
 
@@ -29,6 +30,7 @@ const AuthNavigator = () => {
         name="PasswordResetVerificationScreen"
         component={PasswordResetVerificationScreen}
       />
+      <Stack.Screen name='TermandConditions' component={TermandConditions} />
     </Stack.Navigator>
   );
 };

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -49,19 +49,32 @@ const HomeScreen = ({ navigation }) => {
     const fetchUser = async () => {
       try {
         const currentUser = auth().currentUser;
+
         if (currentUser) {
           const userDoc = await firestore()
             .collection('users')
             .doc(currentUser.uid)
             .get();
+
           if (userDoc.exists) {
-            setUsername(userDoc.data().username || 'Yogi');
+            const userData = userDoc.data();
+            setUsername(
+              userData.username || userData.email?.split('@')[0] || 'Yogi',
+            );
+          } else {
+            setUsername(
+              currentUser.displayName ||
+                currentUser.email?.split('@')[0] ||
+                'Yogi',
+            );
           }
         }
       } catch (error) {
         console.error('Error fetching user:', error);
+        setUsername('Yogi');
       }
     };
+
     fetchUser();
   }, []);
 

--- a/src/screens/SignUpScreen.js
+++ b/src/screens/SignUpScreen.js
@@ -10,14 +10,20 @@ import {
   ScrollView,
   Dimensions,
 } from 'react-native';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import CustomInput from '../components/CustomInput';
 import CustomButton from '../components/CustomButton';
 import { useNavigation } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import auth from '@react-native-firebase/auth';
 import firestore from '@react-native-firebase/firestore';
-import { COLORS, FONTS, globalStyles } from '../styles/globalstyle';
+import { COLORS, globalStyles } from '../styles/globalstyle';
+import { GoogleSignin } from '@react-native-google-signin/google-signin';
+import {
+  getAuth,
+  GoogleAuthProvider,
+  signInWithCredential,
+} from '@react-native-firebase/auth';
+import auth from '@react-native-firebase/auth';
 
 const { width, height } = Dimensions.get('window');
 
@@ -26,6 +32,56 @@ const SignUpScreen = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [username, setUserName] = useState('');
+
+  useEffect(() => {
+    GoogleSignin.configure({
+      webClientId:
+        '148917854976-ul8t50ti31pml63u81dsjhv1tepbcbo7.apps.googleusercontent.com',
+    });
+  }, []);
+
+  const onGoogleButtonPress = async () => {
+    try {
+      await GoogleSignin.hasPlayServices({
+        showPlayServicesUpdateDialog: true,
+      });
+
+      const signInResult = await GoogleSignin.signIn();
+      const idToken = signInResult.data?.idToken || signInResult.idToken;
+
+      if (!idToken) throw new Error('No ID token found');
+
+      const googleCredential = GoogleAuthProvider.credential(idToken);
+
+      // Sign in with Firebase using Google credential
+      const userCredential = await auth().signInWithCredential(
+        googleCredential,
+      );
+      const user = userCredential.user;
+
+      // Save user details to Firestore
+      await firestore()
+        .collection('users')
+        .doc(user.uid)
+        .set(
+          {
+            uid: user.uid,
+            email: user.email,
+            username: user.displayName || '',
+            photoURL: user.photoURL || '',
+            provider: 'google',
+            createdAt: new Date().toISOString(),
+          },
+          { merge: true }, 
+        );
+
+      // Store login status locally
+      await AsyncStorage.setItem('@isLoggedIn', JSON.stringify(true));
+
+    } catch (error) {
+      Alert.alert('Google Sign-In failed', error.message);
+    }
+  };
 
   const SignUp = async () => {
     if (!username || !email || !password) {
@@ -130,24 +186,18 @@ const SignUpScreen = () => {
             <Text style={[globalStyles.bodyText, { fontSize: width * 0.035 }]}>
               Or sign up with
             </Text>
-            <View style={{ flexDirection: 'row', marginTop: height * 0.02 }}>
-              <TouchableOpacity style={styles.socialButton}>
-                <Image
-                  source={require('../assets/images/apple.png')}
-                  style={styles.icon}
-                />
-              </TouchableOpacity>
-              <TouchableOpacity style={styles.socialButton}>
+
+            {/* Custom Google Button (same as SignIn) */}
+            <View style={{ marginTop: height * 0.02, width: '100%' }}>
+              <TouchableOpacity
+                style={styles.googleButton}
+                onPress={onGoogleButtonPress}
+              >
                 <Image
                   source={require('../assets/images/google.png')}
-                  style={styles.icon}
+                  style={styles.googleIcon}
                 />
-              </TouchableOpacity>
-              <TouchableOpacity style={styles.socialButton}>
-                <Image
-                  source={require('../assets/images/fb.png')}
-                  style={styles.icon}
-                />
+                <Text style={styles.googleText}>Continue with Google</Text>
               </TouchableOpacity>
             </View>
 
@@ -174,7 +224,10 @@ const SignUpScreen = () => {
               </TouchableOpacity>
             </View>
 
-            <TouchableOpacity style={{ marginTop: height * 0.015 }} onPress={() => navigation.navigate('TermandConditions')}>
+            <TouchableOpacity
+              style={{ marginTop: height * 0.015 }}
+              onPress={() => navigation.navigate('TermandConditions')}
+            >
               <Text
                 style={[
                   globalStyles.bodyText,
@@ -194,19 +247,30 @@ const SignUpScreen = () => {
 export default SignUpScreen;
 
 const styles = StyleSheet.create({
-  socialButton: {
-    backgroundColor: COLORS.cardBackground,
-    borderRadius: 24,
-    borderWidth: 1,
-    borderColor: COLORS.border,
-    height: width * 0.12,
-    width: width * 0.12,
+  googleButton: {
+    flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    marginHorizontal: width * 0.015,
+    backgroundColor: '#fff',
+    borderRadius: width * 0.035,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    paddingVertical: height * 0.018,
+    paddingHorizontal: width * 0.06,
+    width: '100%',
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 3,
+    elevation: 2,
   },
-  icon: {
-    width: width * 0.08,
-    height: width * 0.08,
+  googleIcon: {
+    width: width * 0.06,
+    height: width * 0.06,
+    marginRight: width * 0.03,
+  },
+  googleText: {
+    fontSize: width * 0.04,
+    color: '#000',
+    fontWeight: '500',
   },
 });

--- a/src/screens/SignUpScreen.js
+++ b/src/screens/SignUpScreen.js
@@ -174,7 +174,7 @@ const SignUpScreen = () => {
               </TouchableOpacity>
             </View>
 
-            <TouchableOpacity style={{ marginTop: height * 0.015 }}>
+            <TouchableOpacity style={{ marginTop: height * 0.015 }} onPress={() => navigation.navigate('TermandConditions')}>
               <Text
                 style={[
                   globalStyles.bodyText,

--- a/src/screens/TermandConditions.js
+++ b/src/screens/TermandConditions.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import {
+  SafeAreaView,
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  Alert,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { COLORS, FONTS } from '../styles/globalstyle';
+
+const TermsAndConditions = () => {
+  const navigation = useNavigation();
+
+  const handleAccept = () => {
+    Alert.alert('Thank you!', 'You have accepted the Terms and Conditions.');
+    navigation.replace('SignUpScreen'); // Replace with your main screen
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.header}>Terms and Conditions</Text>
+      <ScrollView
+        style={styles.scrollContainer}
+        showsVerticalScrollIndicator={true}
+      >
+        <Text style={styles.text}>
+          Welcome to our Yoga App. Please read these Terms and Conditions
+          carefully before using our app:
+        </Text>
+        <View style={styles.bulletContainer}>
+          <Text style={styles.bulletText}>
+            {'\u2022'} Acceptance of Terms: By using this app, you agree to
+            comply with and be bound by these terms.
+          </Text>
+          <Text style={styles.bulletText}>
+            {'\u2022'} Use of App: You must be at least 18 years old to use this
+            app. The app is intended for personal, non-commercial use.
+          </Text>
+          <Text style={styles.bulletText}>
+            {'\u2022'} Health Disclaimer: Yoga involves physical activity.
+            Consult your physician before starting any new fitness program. The
+            app is not responsible for any injuries or health issues arising
+            from your use.
+          </Text>
+          <Text style={styles.bulletText}>
+            {'\u2022'} Content Ownership: All content, videos, and images in
+            this app are owned by us or our licensors. Do not copy, reproduce,
+            or distribute without permission.
+          </Text>
+          <Text style={styles.bulletText}>
+            {'\u2022'} User Conduct: You agree not to misuse the app, post
+            harmful content, or engage in any illegal activities.
+          </Text>
+          <Text style={styles.bulletText}>
+            {'\u2022'} Privacy: Your data is handled according to our Privacy
+            Policy. By using the app, you consent to the collection and use of
+            data as described.
+          </Text>
+          <Text style={styles.bulletText}>
+            {'\u2022'} Termination: We reserve the right to suspend or terminate
+            your access for violation of terms.
+          </Text>
+          <Text style={styles.bulletText}>
+            {'\u2022'} Changes to Terms: We may update these Terms at any time.
+            Continued use of the app indicates acceptance of changes.
+          </Text>
+        </View>
+        <Text style={[styles.text, { marginTop: 10 }]}>
+          By tapping “Accept”, you acknowledge that you have read and agree to
+          these Terms and Conditions.
+        </Text>
+      </ScrollView>
+      <View style={styles.buttonContainer}>
+        <TouchableOpacity style={styles.button} onPress={handleAccept}>
+          <Text style={styles.buttonText}>Accept</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default TermsAndConditions;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: COLORS.background,
+    paddingHorizontal: 20,
+  },
+  header: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: COLORS.primary,
+    marginVertical: 20,
+    textAlign: 'center',
+  },
+  scrollContainer: {
+    flex: 1,
+  },
+  text: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: COLORS.black,
+    marginBottom: 10,
+  },
+  bulletContainer: {
+    paddingLeft: 10,
+  },
+  bulletText: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: COLORS.black,
+    marginBottom: 8,
+  },
+  buttonContainer: {
+    paddingVertical: 20,
+    alignItems: 'center',
+  },
+  button: {
+    backgroundColor: COLORS.primary,
+    paddingVertical: 15,
+    paddingHorizontal: 50,
+    borderRadius: 30,
+  },
+  buttonText: {
+    color: COLORS.white,
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+});


### PR DESCRIPTION
### Changes
- Updated HomeScreen to fetch and display the logged-in user’s username from Firestore.
- Added fallback to Firebase Auth `displayName` or email prefix if no user document exists.
- Ensures greeting text ("Hello, {username} 👋") is always populated, regardless of sign-up method.

### Why
- Improves personalization by showing the correct username after login/signup.
- Handles both email/password and Google sign-in flows gracefully.

### Notes
- Future improvement: ensure all sign-up flows store a `username` in Firestore to avoid fallback usage.
